### PR TITLE
fixed <head> regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jlopezxs/express-inline-css.git"
+    "url": "git+https://github.com/selfagency/express-inline-css.git"
   },
   "bugs": {
     "url": "https://github.com/jlopezxs/express-inline-css/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.5",
+  "version": "1.2.3",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/selfagency/express-inline-css.git"
+    "url": "git+https://github.com/jlopezxs/express-inline-css.git"
   },
   "bugs": {
     "url": "https://github.com/jlopezxs/express-inline-css/issues"

--- a/src/index.js
+++ b/src/index.js
@@ -61,14 +61,14 @@ function expressCriticalCSS ({
           if (!cssFilePath) {
             console.warning('express-inline-css: cssFilePath is required')
           }
-          res.send(html.replace(/(<head>.?)/g, `$1${cache[cacheKey] || ''}`))
+          res.send(html.replace(/(<head>)/i, `$1${cache[cacheKey] || ''}`))
         } else {
           _getStylesheet().then(stylesheet => {
             const cssRules = _extractCss({ stylesheet, selectors: classSelectors
             }).join('')
             const style = `<style>${cssRules}</style>`
             cache[cacheKey] = style
-            res.send(html.replace(/(<head>.?)/g, `$1${style}`))
+            res.send(html.replace(/(<head>)/i, `$1${style}`))
           }).catch(err => {
             return next(err)
           })

--- a/src/index.js
+++ b/src/index.js
@@ -61,14 +61,14 @@ function expressCriticalCSS ({
           if (!cssFilePath) {
             console.warning('express-inline-css: cssFilePath is required')
           }
-          res.send(html.replace(/(<head>)/i, `$1${cache[cacheKey] || ''}`))
+          res.send(html.replace(/(<\/head>)/i, `${cache[cacheKey] || ''}$1`))
         } else {
           _getStylesheet().then(stylesheet => {
             const cssRules = _extractCss({ stylesheet, selectors: classSelectors
             }).join('')
             const style = `<style>${cssRules}</style>`
             cache[cacheKey] = style
-            res.send(html.replace(/(<head>)/i, `$1${style}`))
+            res.send(html.replace(/(<\/head>)/i, `${style}$1`))
           }).catch(err => {
             return next(err)
           })


### PR DESCRIPTION
the way in which you had your regex configured, it inserted the stylesheet after the first character following `<head>`. if you ran the middleware on minified html, it would insert itself into the beginning of the tag immediately following `<head>`. in my case, this is what it was doing:

```
<head><<style>blockquote,body,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,hr,html,iframe,legend,li,ol,p,pre,textarea,ul{margin:0;padding:0}blockquote,body,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,hr,html,iframe,legend,li,ol,p,pre,textarea,ul{margin:0;padding:0}blockquote,body,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,hr,html,iframe,legend,li,ol,p,pre,textarea,ul{margin:0;padding:0}blockquote,body,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,hr,html,iframe,legend,li,ol,p,pre,textarea,ul{margin:0;padding:0}blockquote,body,dd,dl,dt,fieldset,figure,h1,h2,h3,h4,h5,h6,hr,html,iframe,legend,li,ol,p,pre,textarea,ul{margin:0;padding:0} [...] </style>title> [...]
```

this patch resolves this issue by selecting only the `<head>` tag and not the successive character.