### PR TITLE
insertion adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jlopezxs/express-inline-css.git"
+    "url": "git+https://github.com/selfagency/express-inline-css.git"
   },
   "bugs": {
     "url": "https://github.com/jlopezxs/express-inline-css/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-inline-css",
-  "version": "1.2.5",
+  "version": "1.2.3",
   "description": "Express inline CSS generator",
   "license": "MIT",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/selfagency/express-inline-css.git"
+    "url": "git+https://github.com/jlopezxs/express-inline-css.git"
   },
   "bugs": {
     "url": "https://github.com/jlopezxs/express-inline-css/issues"

--- a/src/index.js
+++ b/src/index.js
@@ -61,14 +61,14 @@ function expressCriticalCSS ({
           if (!cssFilePath) {
             console.warning('express-inline-css: cssFilePath is required')
           }
-          res.send(html.replace(/(<head>.?)/g, `$1${cache[cacheKey] || ''}`))
+          res.send(html.replace(/(<head>)/i, `$1${cache[cacheKey] || ''}`))
         } else {
           _getStylesheet().then(stylesheet => {
             const cssRules = _extractCss({ stylesheet, selectors: classSelectors
             }).join('')
             const style = `<style>${cssRules}</style>`
             cache[cacheKey] = style
-            res.send(html.replace(/(<head>.?)/g, `$1${style}`))
+            res.send(html.replace(/(<head>)/i, `$1${style}`))
           }).catch(err => {
             return next(err)
           })

--- a/src/index.js
+++ b/src/index.js
@@ -61,14 +61,14 @@ function expressCriticalCSS ({
           if (!cssFilePath) {
             console.warning('express-inline-css: cssFilePath is required')
           }
-          res.send(html.replace(/(<head>)/i, `$1${cache[cacheKey] || ''}`))
+          res.send(html.replace(/(<\/head>)/i, `${cache[cacheKey] || ''}$1`))
         } else {
           _getStylesheet().then(stylesheet => {
             const cssRules = _extractCss({ stylesheet, selectors: classSelectors
             }).join('')
             const style = `<style>${cssRules}</style>`
             cache[cacheKey] = style
-            res.send(html.replace(/(<head>)/i, `$1${style}`))
+            res.send(html.replace(/(<\/head>)/i, `${style}$1`))
           }).catch(err => {
             return next(err)
           })


### PR DESCRIPTION
there was an issue with the regex for `<head>` that would cause the `<style>` tag to be inserted after the immediate successive `<` following `<head>` when the html was minified. i referenced this in #9.

i then did some html validation testing and discovered that because of the placement of the `<style>` tag at the top of the `<head>` tag the html wouldn't validate. so i moved it to right before `</head>` instead.